### PR TITLE
rename deprecated bs4 function

### DIFF
--- a/mkdocs_swagger_ui_tag/plugin.py
+++ b/mkdocs_swagger_ui_tag/plugin.py
@@ -291,7 +291,7 @@ class SwaggerUIPlugin(BasePlugin):
         iframe["style"] = "overflow:hidden;width:100%;"
         iframe["width"] = "100%"
         iframe["class"] = "swagger-ui-iframe"
-        swagger_ui_ele.replaceWith(iframe)
+        swagger_ui_ele.replace_with(iframe)
 
     def process_options(self, config, swagger_ui_ele):
         """Retrieve Swagger UI options from attribute and use config options as default"""


### PR DESCRIPTION
I'm currently getting this warning when running mkdocs on my project:
```
INFO    -  DeprecationWarning: Call to deprecated method replaceWith. (Replaced by replace_with) --
           Deprecated since version 4.0.0.
```

This PR fixes it (tested)