### PR TITLE
fix: copy oauth2-redirect.js to assets/swagger-ui/ in on_post_build

### DIFF
--- a/mkdocs_swagger_ui_tag/plugin.py
+++ b/mkdocs_swagger_ui_tag/plugin.py
@@ -425,3 +425,7 @@ class SwaggerUIPlugin(BasePlugin):
             os.path.join(base_path, "swagger-ui", "oauth2-redirect.html"),
             os.path.join(swagger_ui_path, "oauth2-redirect.html"),
         )
+        utils.copy_file(
+            os.path.join(base_path, "swagger-ui", "oauth2-redirect.js"),
+            os.path.join(swagger_ui_path, "oauth2-redirect.js"),
+        )

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -534,6 +534,7 @@ def test_static(tmp_path):
     mkdocs_file = "mkdocs.yml"
     testproject_path = validate_mkdocs_file(tmp_path, f"tests/fixtures/{mkdocs_file}")
     assert (testproject_path / "site/assets/swagger-ui/oauth2-redirect.html").exists()
+    assert (testproject_path / "site/assets/swagger-ui/oauth2-redirect.js").exists()
     js_files = [
         "swagger-ui-bundle.js",
         "swagger-ui-bundle.js.map",


### PR DESCRIPTION
## Summary

Fixes #45.

`on_post_build` in v0.8.0 copies `oauth2-redirect.html` to `assets/swagger-ui/` but does not copy `oauth2-redirect.js`, which was added in the same commit that refactored the HTML from a self-contained 74-line inline script into a minimal stub:

```html
<!doctype html><html lang="en-US"><body><script src="oauth2-redirect.js"></script></body></html>
```

Because `oauth2-redirect.js` was never copied to the built site, the browser got a 404 for it, silently breaking the Swagger UI OAuth2 authorize flow for all sites built with v0.8.0.

## Change

**`mkdocs_swagger_ui_tag/plugin.py`** — add one `copy_file` call in `on_post_build` immediately after the existing `oauth2-redirect.html` copy:

```python
utils.copy_file(
    os.path.join(base_path, "swagger-ui", "oauth2-redirect.js"),
    os.path.join(swagger_ui_path, "oauth2-redirect.js"),
)
```

**`tests/test_builds.py`** — extend `test_static` to assert `oauth2-redirect.js` is present in the build output alongside `oauth2-redirect.html`.

## How we tested this

We hit this bug in production on a real MkDocs site using v0.8.0 and confirmed the fix works end-to-end before filing the upstream PR:

1. **Reproduced** — Chrome DevTools Network tab showed a `404 Not Found` for `assets/swagger-ui/oauth2-redirect.js` on the live site, breaking the Swagger UI OAuth2 Authorize flow.
2. **Workaround** — added a MkDocs hook to copy the missing file post-build; the site immediately returned `200 OK` for `oauth2-redirect.js` and the OAuth2 flow completed successfully.
3. **Upstream fix** — confirmed the one-line `copy_file` addition in `on_post_build` is the correct permanent fix. All 19 existing tests pass:

```
============================= 19 passed in 9.00s ==============================
```